### PR TITLE
Fix for incorrect syntax for "postinstall" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint": "tslint \"src/**/*.ts\" --project ./tsconfig.json",
     "scss-lint": "scss-lint",
     "outdated": "npm outdated --depth 0",
-    "post-install": "webdriver-manager update --standalone",
+    "postinstall": "webdriver-manager update --standalone",
     "precommit": "npm run lint && npm run scss-lint",
     "prepush": "npm test",
     "commitmsg": "validate-commit-msg"


### PR DESCRIPTION
`"post-install"` should be `"postinstall"`:
https://docs.npmjs.com/misc/scripts#examples

Otherwise required binaries are missing and e2e tests will fail:

Error in console:

```ps
PS C:\repos\ionic-boilerplate> npm run e2e

> ionic2-boilerplate@0.27.0 e2e C:\repos\ionic-boilerplate
> node config/protractor.server.js

Started web server on 127.0.0.1:63566
Report destination:   coverage\protractor\e2e-report.html
(node:19928) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
[10:17:43] I/launcher - Running 1 instances of WebDriver
[10:17:43] I/direct - Using ChromeDriver directly...
[10:17:43] E/direct - Error code: 135
[10:17:43] E/direct - Error message: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.

. . . . . 

```